### PR TITLE
DASD-94 Uniquify Resources

### DIFF
--- a/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
+++ b/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
@@ -4,17 +4,17 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-ResourceGroup Tests" -Tag "Acceptance-ARM" {
 
     It "Should create a Resouce Group and return two outputs" {
-        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $Config.resourceGroupName+$Config.suffix
+        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $($Config.resourceGroupName+$Config.suffix)
         $Result.Count | Should Be 2
     }
 
     It "Should create a Resource Group with the correct name" {
-        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName+$Config.suffix -ErrorAction SilentlyContinue
-        $Result.ResourceGroupName | Should Be $Config.resourceGroupName+$Config.suffix
+        $Result = Get-AzureRMResourceGroup -Name $($Config.resourceGroupName+$Config.suffix) -ErrorAction SilentlyContinue
+        $Result.ResourceGroupName | Should Be $($Config.resourceGroupName+$Config.suffix)
     }
 
     It "Should create a Resource Group in the correct location" {
-        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName+$Config.suffix -Location "$Config.location"
+        $Result = Get-AzureRMResourceGroup -Name $($Config.resourceGroupName+$Config.suffix) -Location "$Config.location"
         $Result.location | Should Be $Config.location.Replace(" ","").ToLower()
     }
 }

--- a/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
+++ b/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
@@ -4,17 +4,17 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-ResourceGroup Tests" -Tag "Acceptance-ARM" {
 
     It "Should create a Resouce Group and return two outputs" {
-        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $Config.resourceGroupName
+        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $Config.resourceGroupName+$Config.suffix
         $Result.Count | Should Be 2
     }
 
     It "Should create a Resource Group with the correct name" {
-        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName -ErrorAction SilentlyContinue
-        $Result.ResourceGroupName | Should Be $Config.resourceGroupName
+        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName+$Config.suffix -ErrorAction SilentlyContinue
+        $Result.ResourceGroupName | Should Be $Config.resourceGroupName+$Config.suffix
     }
 
     It "Should create a Resource Group in the correct location" {
-        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName -Location "$Config.location"
+        $Result = Get-AzureRMResourceGroup -Name $Config.resourceGroupName+$Config.suffix -Location "$Config.location"
         $Result.location | Should Be $Config.location.Replace(" ","").ToLower()
     }
 }

--- a/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
+++ b/Tests/AT001.New-ResourceGroup.Acceptance.Tests.ps1
@@ -3,18 +3,20 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-ResourceGroup Tests" -Tag "Acceptance-ARM" {
 
+    $ResourceGroupName = "$($Config.resourceGroupName)$($Config.suffix)"
+
     It "Should create a Resouce Group and return two outputs" {
-        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $($Config.resourceGroupName+$Config.suffix)
+        $Result = .\New-ResourceGroup.ps1 -Location "$($Config.location)" -Name $ResourceGroupName
         $Result.Count | Should Be 2
     }
 
     It "Should create a Resource Group with the correct name" {
-        $Result = Get-AzureRMResourceGroup -Name $($Config.resourceGroupName+$Config.suffix) -ErrorAction SilentlyContinue
-        $Result.ResourceGroupName | Should Be $($Config.resourceGroupName+$Config.suffix)
+        $Result = Get-AzureRMResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+        $Result.ResourceGroupName | Should Be $ResourceGroupName
     }
 
     It "Should create a Resource Group in the correct location" {
-        $Result = Get-AzureRMResourceGroup -Name $($Config.resourceGroupName+$Config.suffix) -Location "$Config.location"
+        $Result = Get-AzureRMResourceGroup -Name $ResourceGroupName -Location "$Config.location"
         $Result.location | Should Be $Config.location.Replace(" ","").ToLower()
     }
 }

--- a/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
+++ b/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
@@ -6,7 +6,7 @@ Describe "New-ClassicStorageAccount Tests" -Tag "Acceptance-ASM" {
     It "Should create a Storage Account and return one output" {
         $Params = @{
             Location = $Config.location
-            Name = $Config.classicStorageAccountName+$Config.suffix
+            Name = $($Config.classicStorageAccountName+$Config.suffix)
             ContainerName = $Config.classicStorageContainerName
         }
         $Result = .\New-ClassicStorageAccount.ps1 @Params
@@ -14,18 +14,18 @@ Describe "New-ClassicStorageAccount Tests" -Tag "Acceptance-ASM" {
     }
 
     It "Should create a Storage Account with the correct name" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName+$Config.suffix
-        $Result.StorageAccountName | Should Be $Config.classicStorageAccountName+$Config.suffix
+        $Result = Get-AzureStorageAccount -StorageAccountName $($Config.classicStorageAccountName+$Config.suffix)
+        $Result.StorageAccountName | Should Be $($Config.classicStorageAccountName+$Config.suffix)
     }
 
     It "Should create a Storage Account in the correct location" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName+$Config.suffix
+        $Result = Get-AzureStorageAccount -StorageAccountName $($Config.classicStorageAccountName+$Config.suffix)
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create a Storage Container in the Storage Account" {
         $Subscription = Get-AzureSubscription -Current
-        Set-AzureSubscription -CurrentStorageAccountName $Config.classicStorageAccountName+$Config.suffix -SubscriptionId $Subscription.SubscriptionId
+        Set-AzureSubscription -CurrentStorageAccountName $($Config.classicStorageAccountName+$Config.suffix) -SubscriptionId $Subscription.SubscriptionId
         $Container = Get-AzureStorageContainer -Name $Container -ErrorAction SilentlyContinue
         $Container.Count | Should Be 1
     }

--- a/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
+++ b/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
@@ -3,10 +3,12 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-ClassicStorageAccount Tests" -Tag "Acceptance-ASM" {
 
+    $StorageAccountName = "$($Config.classicStorageAccountName)$($Config.suffix)"
+
     It "Should create a Storage Account and return one output" {
         $Params = @{
             Location = $Config.location
-            Name = $($Config.classicStorageAccountName+$Config.suffix)
+            Name = $StorageAccountName
             ContainerName = $Config.classicStorageContainerName
         }
         $Result = .\New-ClassicStorageAccount.ps1 @Params
@@ -14,18 +16,18 @@ Describe "New-ClassicStorageAccount Tests" -Tag "Acceptance-ASM" {
     }
 
     It "Should create a Storage Account with the correct name" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $($Config.classicStorageAccountName+$Config.suffix)
-        $Result.StorageAccountName | Should Be $($Config.classicStorageAccountName+$Config.suffix)
+        $Result = Get-AzureStorageAccount -StorageAccountName $StorageAccountName
+        $Result.StorageAccountName | Should Be $StorageAccountName
     }
 
     It "Should create a Storage Account in the correct location" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $($Config.classicStorageAccountName+$Config.suffix)
+        $Result = Get-AzureStorageAccount -StorageAccountName $StorageAccountName
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create a Storage Container in the Storage Account" {
         $Subscription = Get-AzureSubscription -Current
-        Set-AzureSubscription -CurrentStorageAccountName $($Config.classicStorageAccountName+$Config.suffix) -SubscriptionId $Subscription.SubscriptionId
+        Set-AzureSubscription -CurrentStorageAccountName $StorageAccountName -SubscriptionId $Subscription.SubscriptionId
         $Container = Get-AzureStorageContainer -Name $Container -ErrorAction SilentlyContinue
         $Container.Count | Should Be 1
     }

--- a/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
+++ b/Tests/AT002.New-ClassicStorageAccount.Acceptance.Tests.ps1
@@ -4,23 +4,28 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-ClassicStorageAccount Tests" -Tag "Acceptance-ASM" {
 
     It "Should create a Storage Account and return one output" {
-        $Result = .\New-ClassicStorageAccount.ps1 -Location $Config.location -Name $Config.classicStorageAccountName -ContainerName $Config.classicStorageContainerName
+        $Params = @{
+            Location = $Config.location
+            Name = $Config.classicStorageAccountName+$Config.suffix
+            ContainerName = $Config.classicStorageContainerName
+        }
+        $Result = .\New-ClassicStorageAccount.ps1 @Params
         $Result.Count | Should Be 1
     }
 
     It "Should create a Storage Account with the correct name" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName
-        $Result.StorageAccountName | Should Be $Config.classicStorageAccountName
+        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName+$Config.suffix
+        $Result.StorageAccountName | Should Be $Config.classicStorageAccountName+$Config.suffix
     }
 
     It "Should create a Storage Account in the correct location" {
-        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName
+        $Result = Get-AzureStorageAccount -StorageAccountName $Config.classicStorageAccountName+$Config.suffix
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create a Storage Container in the Storage Account" {
         $Subscription = Get-AzureSubscription -Current
-        Set-AzureSubscription -CurrentStorageAccountName $Config.classicStorageAccountName -SubscriptionId $Subscription.SubscriptionId
+        Set-AzureSubscription -CurrentStorageAccountName $Config.classicStorageAccountName+$Config.suffix -SubscriptionId $Subscription.SubscriptionId
         $Container = Get-AzureStorageContainer -Name $Container -ErrorAction SilentlyContinue
         $Container.Count | Should Be 1
     }

--- a/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
+++ b/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
@@ -4,17 +4,17 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-CloudService Tests" -Tag "Acceptance-ASM" {
 
     It "Should create a Cloud Service and return no outputs" {
-        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $Config.cloudServiceName
+        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $Config.cloudServiceName+$Config.suffix
         $Result.Count | Should Be 0
     }
 
     It "Should create a Cloud Service with the correct name" {
-        $Result = Get-AzureService -ServiceName $Config.cloudServiceName -ErrorAction SilentlyContinue
-        $Result.ServiceName | Should Be $Config.cloudServiceName
+        $Result = Get-AzureService -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue
+        $Result.ServiceName | Should Be $Config.cloudServiceName+$Config.suffix
     }
 
     It "Should create a Cloud Service in the correct location" {
-        $Result = Get-AzureService -ServiceName $Config.cloudServiceName -ErrorAction SilentlyContinue
+        $Result = Get-AzureService -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue
         $Result.Location | Should Be $Config.location
     }
 }

--- a/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
+++ b/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
@@ -3,18 +3,20 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-CloudService Tests" -Tag "Acceptance-ASM" {
 
+    $CloudServiceName = "$($Config.cloudServiceName)$($Config.suffix)"
+
     It "Should create a Cloud Service and return no outputs" {
-        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $($Config.cloudServiceName+$Config.suffix)
+        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $CloudServiceName
         $Result.Count | Should Be 0
     }
 
     It "Should create a Cloud Service with the correct name" {
-        $Result = Get-AzureService -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue
-        $Result.ServiceName | Should Be $($Config.cloudServiceName+$Config.suffix)
+        $Result = Get-AzureService -ServiceName $CloudServiceName -ErrorAction SilentlyContinue
+        $Result.ServiceName | Should Be $CloudServiceName
     }
 
     It "Should create a Cloud Service in the correct location" {
-        $Result = Get-AzureService -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue
+        $Result = Get-AzureService -ServiceName $CloudServiceName -ErrorAction SilentlyContinue
         $Result.Location | Should Be $Config.location
     }
 }

--- a/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
+++ b/Tests/AT003.New-CloudService.Acceptance.Tests.ps1
@@ -4,17 +4,17 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-CloudService Tests" -Tag "Acceptance-ASM" {
 
     It "Should create a Cloud Service and return no outputs" {
-        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $Config.cloudServiceName+$Config.suffix
+        $Result = .\New-CloudService.ps1 -Location $Config.location -Name $($Config.cloudServiceName+$Config.suffix)
         $Result.Count | Should Be 0
     }
 
     It "Should create a Cloud Service with the correct name" {
-        $Result = Get-AzureService -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue
-        $Result.ServiceName | Should Be $Config.cloudServiceName+$Config.suffix
+        $Result = Get-AzureService -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue
+        $Result.ServiceName | Should Be $($Config.cloudServiceName+$Config.suffix)
     }
 
     It "Should create a Cloud Service in the correct location" {
-        $Result = Get-AzureService -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue
+        $Result = Get-AzureService -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue
         $Result.Location | Should Be $Config.location
     }
 }

--- a/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
+++ b/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
@@ -16,10 +16,8 @@ Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
         $AppliedCert.Thumbprint | Should Be $Cert.Thumbprint
     }
     
+    # --- Remove test certificate from local store    
     Get-ChildItem Cert:\CurrentUser\My\$Cert.Thumbprint | Remove-Item -Confirm:$false
 }
-
-# --- Remove test certificate from local store
-
 
 Pop-Location

--- a/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
+++ b/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
@@ -1,18 +1,24 @@
 $Config = Get-Content $PSScriptRoot\..\Tests\Acceptance.Config.json -Raw | ConvertFrom-Json
 Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
+# --- Certificate file must exist in the same folder as this test script
+$CertPath = "$PSScriptRoot\$($Config.certificateName)"
+
 Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
+
+    $CloudServiceName = "$($Config.cloudServiceName)$($Config.suffix)"
+
     # --- Set up test certificate
     $SecurePassword = $Config.certificatePassword | ConvertTo-SecureString -AsPlainText -Force
-    $Cert = Import-PfxCertificate -FilePath $Config.certificatePath -Password $SecurePassword -CertStoreLocation Cert:\CurrentUser\My
+    $Cert = Import-PfxCertificate -FilePath $CertPath -Password $SecurePassword -CertStoreLocation Cert:\CurrentUser\My
 
     It "Should apply a Certificate to the Cloud Service and return no outputs" {        
-        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $($Config.cloudServiceName+$Config.suffix) -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
+        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $CloudServiceName -CertificatePath $CertPath -CertificatePassword $Config.certificatePassword
         $Result.Count | Should Be 0
     }
 
     It "Applied thumbprint should exist on the cloud service" {
-        $AppliedCert = Get-AzureCertificate -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue        
+        $AppliedCert = Get-AzureCertificate -ServiceName $CloudServiceName -ErrorAction SilentlyContinue        
         $AppliedCert.Thumbprint | Should Be $Cert.Thumbprint
     }
     

--- a/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
+++ b/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
@@ -1,11 +1,10 @@
 $Config = Get-Content $PSScriptRoot\..\Tests\Acceptance.Config.json -Raw | ConvertFrom-Json
 Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
-# --- Set up test certificate
-$SecurePassword = $Config.certificatePassword | ConvertTo-SecureString -AsPlainText -Force
-$Cert = Import-PfxCertificate -FilePath $Config.certificatePath -Password $SecurePassword -CertStoreLocation Cert:\CurrentUser\My
-
 Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
+    # --- Set up test certificate
+    $SecurePassword = $Config.certificatePassword | ConvertTo-SecureString -AsPlainText -Force
+    $Cert = Import-PfxCertificate -FilePath $Config.certificatePath -Password $SecurePassword -CertStoreLocation Cert:\CurrentUser\My
 
     It "Should apply a Certificate to the Cloud Service and return no outputs" {        
         $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $($Config.cloudServiceName+$Config.suffix) -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
@@ -16,9 +15,11 @@ Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
         $AppliedCert = Get-AzureCertificate -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue        
         $AppliedCert.Thumbprint | Should Be $Cert.Thumbprint
     }
+    
+    Get-ChildItem Cert:\CurrentUser\My\$Cert.Thumbprint | Remove-Item -Confirm:$false
 }
 
 # --- Remove test certificate from local store
-Get-ChildItem Cert:\CurrentUser\My\$Cert.Thumbprint | Remove-Item -Confirm:$false
+
 
 Pop-Location

--- a/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
+++ b/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
@@ -8,12 +8,12 @@ $Cert = Import-PfxCertificate -FilePath $Config.certificatePath -Password $Secur
 Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
 
     It "Should apply a Certificate to the Cloud Service and return no outputs" {        
-        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $Config.cloudServiceName+$Config.suffix -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
+        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $($Config.cloudServiceName+$Config.suffix) -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
         $Result.Count | Should Be 0
     }
 
     It "Applied thumbprint should exist on the cloud service" {
-        $AppliedCert = Get-AzureCertificate -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue        
+        $AppliedCert = Get-AzureCertificate -ServiceName $($Config.cloudServiceName+$Config.suffix) -ErrorAction SilentlyContinue        
         $AppliedCert.Thumbprint | Should Be $Cert.Thumbprint
     }
 }

--- a/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
+++ b/Tests/AT004.Set-CloudServiceCertificate.Acceptance.Tests.ps1
@@ -8,12 +8,12 @@ $Cert = Import-PfxCertificate -FilePath $Config.certificatePath -Password $Secur
 Describe "Set-CloudServiceCertificate Tests" -Tag "Acceptance-ASM" {
 
     It "Should apply a Certificate to the Cloud Service and return no outputs" {        
-        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $Config.cloudServiceName -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
+        $Result = .\Set-CloudServiceCertificate.ps1 -ServiceName $Config.cloudServiceName+$Config.suffix -CertificatePath $Config.certificatePath -CertificatePassword $Config.certificatePassword
         $Result.Count | Should Be 0
     }
 
     It "Applied thumbprint should exist on the cloud service" {
-        $AppliedCert = Get-AzureCertificate -ServiceName $Config.cloudServiceName -ErrorAction SilentlyContinue        
+        $AppliedCert = Get-AzureCertificate -ServiceName $Config.cloudServiceName+$Config.suffix -ErrorAction SilentlyContinue        
         $AppliedCert.Thumbprint | Should Be $Cert.Thumbprint
     }
 }

--- a/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
+++ b/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
@@ -3,29 +3,33 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "Move-Resource Tests" -Tag "Acceptance-ARM" {
 
+    $DestinationResourceGroup = "$($Config.resourceGroupName)$($Config.suffix)"
+    $CloudServiceName = "$($Config.cloudServiceName)$($Config.suffix)"
+    $StorageAccountName = "$($Config.classicStorageAccountName)$($Config.suffix)"
+
     It "Should move given resources to a named Resource Group" {
         $Resources = @(
-            $($Config.classicStorageAccountName+$Config.suffix),
-            $($Config.cloudServiceName+$Config.suffix)
+            "$($Config.classicStorageAccountName)$($Config.suffix)",
+            "$($Config.cloudServiceName)$($Config.suffix)"
         )
 
-        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $($Config.resourceGroupName+$Config.suffix)
+        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $DestinationResourceGroup
 
         $ResourcesFound = 0
-        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $($Config.cloudServiceName+$Config.suffix)).ResourceGroupName
-        if ($CloudServiceResourceGroup -eq $($Config.resourceGroupName+$Config.suffix)) {
+        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $CloudServiceName).ResourceGroupName
+        if ($CloudServiceResourceGroup -eq $DestinationResourceGroup) {
             $ResourcesFound = $ResourcesFound+1
         }
 
-        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $($Config.classicStorageAccountName+$Config.suffix)).ResourceGroupName
-        if ($StorageAccountResourceGroup -eq $($Config.resourceGroupName+$Config.suffix)){
+        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $StorageAccountName).ResourceGroupName
+        if ($StorageAccountResourceGroup -eq $DestinationResourceGroup){
             $ResourcesFound = $ResourcesFound+1
         }
         $ResourcesFound | Should Be 2
     }
 
     It "Should remove the source Cloud Service Resource Group created" {
-        {Get-AzureRmResourceGroup -Name $($Config.cloudServiceName+$Config.suffix) -ErrorAction Stop} | Should Throw
+        {Get-AzureRmResourceGroup -Name $CloudServiceName -ErrorAction Stop} | Should Throw
     }
 
     It "Should remove the source Storage Account Resource group created" {

--- a/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
+++ b/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
@@ -5,27 +5,27 @@ Describe "Move-Resource Tests" -Tag "Acceptance-ARM" {
 
     It "Should move given resources to a named Resource Group" {
         $Resources = @(
-            $Config.classicStorageAccountName+$Config.suffix,
-            $Config.cloudServiceName+$Config.suffix
+            $($Config.classicStorageAccountName+$Config.suffix),
+            $($Config.cloudServiceName+$Config.suffix)
         )
 
-        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $Config.resourceGroupName+$Config.suffix
+        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $($Config.resourceGroupName+$Config.suffix)
 
         $ResourcesFound = 0
-        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.cloudServiceName+$Config.suffix).ResourceGroupName
-        if ($CloudServiceResourceGroup -eq $Config.resourceGroupName+$Config.suffix) {
+        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $($Config.cloudServiceName+$Config.suffix)).ResourceGroupName
+        if ($CloudServiceResourceGroup -eq $($Config.resourceGroupName+$Config.suffix)) {
             $ResourcesFound = $ResourcesFound+1
         }
 
-        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.classicStorageAccountName+$Config.suffix).ResourceGroupName
-        if ($StorageAccountResourceGroup -eq $Config.resourceGroupName+$Config.suffix){
+        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $($Config.classicStorageAccountName+$Config.suffix)).ResourceGroupName
+        if ($StorageAccountResourceGroup -eq $($Config.resourceGroupName+$Config.suffix)){
             $ResourcesFound = $ResourcesFound+1
         }
         $ResourcesFound | Should Be 2
     }
 
     It "Should remove the source Cloud Service Resource Group created" {
-        {Get-AzureRmResourceGroup -Name $Config.cloudServiceName+$Config.suffix -ErrorAction Stop} | Should Throw
+        {Get-AzureRmResourceGroup -Name $($Config.cloudServiceName+$Config.suffix) -ErrorAction Stop} | Should Throw
     }
 
     It "Should remove the source Storage Account Resource group created" {

--- a/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
+++ b/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
@@ -5,27 +5,27 @@ Describe "Move-Resource Tests" -Tag "Acceptance-ARM" {
 
     It "Should move given resources to a named Resource Group" {
         $Resources = @(
-            $Config.classicStorageAccountName,
-            $Config.cloudServiceName
+            $Config.classicStorageAccountName+$Config.suffix,
+            $Config.cloudServiceName+$Config.suffix
         )
 
-        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $Config.resourceGroupName
+        $null = .\Move-Resource.ps1 -ResourceName $Resources -DestinationResourceGroup $Config.resourceGroupName+$Config.suffix
 
         $ResourcesFound = 0
-        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.cloudServiceName).ResourceGroupName
-        if ($CloudServiceResourceGroup -eq $Config.resourceGroupName) {
+        $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.cloudServiceName+$Config.suffix).ResourceGroupName
+        if ($CloudServiceResourceGroup -eq $Config.resourceGroupName+$Config.suffix) {
             $ResourcesFound = $ResourcesFound+1
         }
 
-        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.classicStorageAccountName).ResourceGroupName
-        if ($StorageAccountResourceGroup -eq $Config.resourceGroupName){
+        $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $Config.classicStorageAccountName+$Config.suffix).ResourceGroupName
+        if ($StorageAccountResourceGroup -eq $Config.resourceGroupName+$Config.suffix){
             $ResourcesFound = $ResourcesFound+1
         }
         $ResourcesFound | Should Be 2
     }
 
     It "Should remove the source Cloud Service Resource Group created" {
-        {Get-AzureRmResourceGroup -Name $Config.cloudServiceName -ErrorAction Stop} | Should Throw
+        {Get-AzureRmResourceGroup -Name $Config.cloudServiceName+$Config.suffix -ErrorAction Stop} | Should Throw
     }
 
     It "Should remove the source Storage Account Resource group created" {

--- a/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
+++ b/Tests/AT005.Move-Resource.Acceptance.Tests.ps1
@@ -18,12 +18,12 @@ Describe "Move-Resource Tests" -Tag "Acceptance-ARM" {
         $ResourcesFound = 0
         $CloudServiceResourceGroup = (Find-AzureRmResource -ResourceNameEquals $CloudServiceName).ResourceGroupName
         if ($CloudServiceResourceGroup -eq $DestinationResourceGroup) {
-            $ResourcesFound = $ResourcesFound+1
+            $ResourcesFound = $ResourcesFound + 1
         }
 
         $StorageAccountResourceGroup = (Find-AzureRmResource -ResourceNameEquals $StorageAccountName).ResourceGroupName
-        if ($StorageAccountResourceGroup -eq $DestinationResourceGroup){
-            $ResourcesFound = $ResourcesFound+1
+        if ($StorageAccountResourceGroup -eq $DestinationResourceGroup) {
+            $ResourcesFound = $ResourcesFound + 1
         }
         $ResourcesFound | Should Be 2
     }

--- a/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
+++ b/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
@@ -4,7 +4,7 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-ApplicationInsights Tests" -Tag "Acceptance-ARM" {
 
     It "Should create an ApplicationInsights and return a valid instrumentation key" {
-        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $Config.appInsightsName -ResourceGroupName $Config.ResourceGroupName
+        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $Config.appInsightsName+$Config.suffix -ResourceGroupName $Config.ResourceGroupName+$Config.suffix
         $Result.Count | Should Be 1
         $Result.Contains("InstrumentationKey") | Should Be $true
         $Result = $Result.Replace("##vso[task.setvariable variable=InstrumentationKey;]", "")

--- a/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
+++ b/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
@@ -4,7 +4,7 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 Describe "New-ApplicationInsights Tests" -Tag "Acceptance-ARM" {
 
     It "Should create an ApplicationInsights and return a valid instrumentation key" {
-        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $Config.appInsightsName+$Config.suffix -ResourceGroupName $Config.ResourceGroupName+$Config.suffix
+        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $($Config.appInsightsName+$Config.suffix) -ResourceGroupName $($Config.ResourceGroupName+$Config.suffix)
         $Result.Count | Should Be 1
         $Result.Contains("InstrumentationKey") | Should Be $true
         $Result = $Result.Replace("##vso[task.setvariable variable=InstrumentationKey;]", "")

--- a/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
+++ b/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
@@ -12,7 +12,7 @@ Describe "New-ApplicationInsights Tests" -Tag "Acceptance-ARM" {
         $Result.Contains("InstrumentationKey") | Should Be $true
         $Result = $Result.Replace("##vso[task.setvariable variable=InstrumentationKey;]", "")
         $ValidGuid = [System.Guid]::NewGuid()
-        $Success = [System.Guid]::TryParse($Result,[ref]$ValidGuid);
+        $Success = [System.Guid]::TryParse($Result, [ref]$ValidGuid);
         $Success | Should Be $true
     }
 }

--- a/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
+++ b/Tests/AT006.New-ApplicationInsights.Acceptance.Tests.ps1
@@ -3,8 +3,11 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-ApplicationInsights Tests" -Tag "Acceptance-ARM" {
 
+    $ResourceGroupName = "$($Config.ResourceGroupName)$($Config.suffix)"
+    $AppInsightsName = "$($Config.appInsightsName)$($Config.suffix)"
+
     It "Should create an ApplicationInsights and return a valid instrumentation key" {
-        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $($Config.appInsightsName+$Config.suffix) -ResourceGroupName $($Config.ResourceGroupName+$Config.suffix)
+        $Result = .\New-ApplicationInsights.ps1 -Location $Config.location -Name $AppInsightsName -ResourceGroupName $ResourceGroupName
         $Result.Count | Should Be 1
         $Result.Contains("InstrumentationKey") | Should Be $true
         $Result = $Result.Replace("##vso[task.setvariable variable=InstrumentationKey;]", "")

--- a/Tests/AT007.New-AppService.Acceptance.Tests.ps1
+++ b/Tests/AT007.New-AppService.Acceptance.Tests.ps1
@@ -9,10 +9,10 @@ Describe "New-AppService Tests" -Tag "Acceptance-ARM" {
 
     It "Should create an App service and return no outputs" {
         $Params = @{
-            Location = $Config.location
-            ResourceGroupName = $ResourceGroupName
+            Location           = $Config.location
+            ResourceGroupName  = $ResourceGroupName
             AppServicePlanName = $AppServicePlanName
-            AppServiceName = $AppServiceName
+            AppServiceName     = $AppServiceName
         }
         $Result = .\New-AppService.ps1 @params
         $Result.Count | Should Be 0
@@ -27,6 +27,10 @@ Describe "New-AppService Tests" -Tag "Acceptance-ARM" {
         $Result = Get-AzureRmWebApp -ResourceGroupName $ResourceGroupName -Name $AppServiceName
         $Result.Name | Should Be $AppServiceName
     }
+
+    # It "Should create an App service with the correct properties" {
+        
+    # }
 
     It "Should create an App service plan with the correct location" {
         $Result = Get-AzureRmAppServicePlan -ResourceGroupName $ResourceGroupName -Name $AppServicePlanName

--- a/Tests/AT007.New-AppService.Acceptance.Tests.ps1
+++ b/Tests/AT007.New-AppService.Acceptance.Tests.ps1
@@ -6,32 +6,32 @@ Describe "New-AppService Tests" -Tag "Acceptance-ARM" {
     It "Should create an App service and return no outputs" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $Config.resourceGroupName+$Config.suffix
-            AppServicePlanName = $Config.appServicePlanName+$Config.suffix
-            AppServiceName = $Config.appServiceName+$Config.suffix
+            ResourceGroupName = $($Config.resourceGroupName+$Config.suffix)
+            AppServicePlanName = $($Config.appServicePlanName+$Config.suffix)
+            AppServiceName = $($Config.appServiceName+$Config.suffix)
         }
         $Result = .\New-AppService.ps1 @params
         $Result.Count | Should Be 0
     }
 
     It "Should create an App service in the correct location" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName+$Config.suffix -Name $Config.appServiceName+$Config.suffix
+        $Result = Get-AzureRmWebApp -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServiceName+$Config.suffix)
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create an App service with the correct name" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName+$Config.suffix -Name $Config.appServiceName+$Config.suffix
-        $Result.Name | Should Be $Config.appServiceName+$Config.suffix
+        $Result = Get-AzureRmWebApp -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServiceName+$Config.suffix)
+        $Result.Name | Should Be $($Config.appServiceName+$Config.suffix)
     }
 
     It "Should create an App service plan with the correct location" {
-        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $Config.resourceGroupName -Name $Config.appServicePlanName
+        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServicePlanName+$Config.suffix)
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create an App service plan with the correct name" {
-        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $Config.resourceGroupName -Name $Config.appServicePlanName
-        $Result.Name | Should Be $Config.appServicePlanName
+        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServicePlanName+$Config.suffix)
+        $Result.Name | Should Be $($Config.appServicePlanName+$Config.suffix)
     }
 
 }

--- a/Tests/AT007.New-AppService.Acceptance.Tests.ps1
+++ b/Tests/AT007.New-AppService.Acceptance.Tests.ps1
@@ -3,35 +3,39 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-AppService Tests" -Tag "Acceptance-ARM" {
 
+    $ResourceGroupName = "$($Config.resourceGroupName)$($Config.suffix)"
+    $AppServicePlanName = "$($Config.appServicePlanName)$($Config.suffix)"
+    $AppServiceName = "$($Config.appServiceName)$($Config.suffix)"
+
     It "Should create an App service and return no outputs" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $($Config.resourceGroupName+$Config.suffix)
-            AppServicePlanName = $($Config.appServicePlanName+$Config.suffix)
-            AppServiceName = $($Config.appServiceName+$Config.suffix)
+            ResourceGroupName = $ResourceGroupName
+            AppServicePlanName = $AppServicePlanName
+            AppServiceName = $AppServiceName
         }
         $Result = .\New-AppService.ps1 @params
         $Result.Count | Should Be 0
     }
 
     It "Should create an App service in the correct location" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServiceName+$Config.suffix)
+        $Result = Get-AzureRmWebApp -ResourceGroupName $ResourceGroupName -Name $AppServiceName
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create an App service with the correct name" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServiceName+$Config.suffix)
-        $Result.Name | Should Be $($Config.appServiceName+$Config.suffix)
+        $Result = Get-AzureRmWebApp -ResourceGroupName $ResourceGroupName -Name $AppServiceName
+        $Result.Name | Should Be $AppServiceName
     }
 
     It "Should create an App service plan with the correct location" {
-        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServicePlanName+$Config.suffix)
+        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $ResourceGroupName -Name $AppServicePlanName
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create an App service plan with the correct name" {
-        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $($Config.resourceGroupName+$Config.suffix) -Name $($Config.appServicePlanName+$Config.suffix)
-        $Result.Name | Should Be $($Config.appServicePlanName+$Config.suffix)
+        $Result = Get-AzureRmAppServicePlan -ResourceGroupName $ResourceGroupName -Name $AppServicePlanName
+        $Result.Name | Should Be $AppServicePlanName
     }
 
 }

--- a/Tests/AT007.New-AppService.Acceptance.Tests.ps1
+++ b/Tests/AT007.New-AppService.Acceptance.Tests.ps1
@@ -6,22 +6,22 @@ Describe "New-AppService Tests" -Tag "Acceptance-ARM" {
     It "Should create an App service and return no outputs" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $Config.resourceGroupName
-            AppServicePlanName = $Config.appServicePlanName
-            AppServiceName = $Config.appServiceName
+            ResourceGroupName = $Config.resourceGroupName+$Config.suffix
+            AppServicePlanName = $Config.appServicePlanName+$Config.suffix
+            AppServiceName = $Config.appServiceName+$Config.suffix
         }
         $Result = .\New-AppService.ps1 @params
         $Result.Count | Should Be 0
     }
 
     It "Should create an App service in the correct location" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName -Name $Config.appServiceName
+        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName+$Config.suffix -Name $Config.appServiceName+$Config.suffix
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create an App service with the correct name" {
-        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName -Name $Config.appServiceName
-        $Result.Name | Should Be $Config.appServiceName
+        $Result = Get-AzureRmWebApp -ResourceGroupName $Config.resourceGroupName+$Config.suffix -Name $Config.appServiceName+$Config.suffix
+        $Result.Name | Should Be $Config.appServiceName+$Config.suffix
     }
 
     It "Should create an App service plan with the correct location" {

--- a/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
+++ b/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
@@ -8,10 +8,10 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
 
     It "Should create a Service Bus and return one output" {
         $Params = @{
-            Location = $Config.location
+            Location          = $Config.location
             ResourceGroupName = $ResourceGroupName
-            NamespaceName = $ServiceBusName
-            QueueName = $Config.serviceBusQueueName
+            NamespaceName     = $ServiceBusName
+            QueueName         = $Config.serviceBusQueueName
         }
         $Result = .\New-ServiceBus.ps1 @params
         $Result.Count | Should Be 1
@@ -23,7 +23,7 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     }
 
     It "Should create specified Service Bus queues" {
-        foreach($Queue in $Config.serviceBusQueueName){
+        foreach ($Queue in $Config.serviceBusQueueName) {
             $Queue.Trim()
             $ExistingQueue = Get-AzureRmServiceBusQueue -ResourceGroup $ResourceGroupName -NamespaceName $ServiceBusName -QueueName $Queue
             $ExistingQueue.Name | Should Be $Queue

--- a/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
+++ b/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
@@ -6,8 +6,8 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     It "Should create a Service Bus and return one output" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $Config.resourceGroupName+$Config.suffix
-            NamespaceName = $Config.serviceBusNamespaceName+$Config.suffix
+            ResourceGroupName = $($Config.resourceGroupName+$Config.suffix)
+            NamespaceName = $($Config.serviceBusNamespaceName+$Config.suffix)
             QueueName = $Config.serviceBusQueueName
         }
         $Result = .\New-ServiceBus.ps1 @params
@@ -15,7 +15,7 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     }
 
     It "Should create a Service Bus in the correct location" {
-        $Result = Get-AzureRmServiceBusNamespace -Name $Config.serviceBusNamespaceName+$Config.suffix -ResourceGroup $Config.resourceGroupName+$Config.suffix
+        $Result = Get-AzureRmServiceBusNamespace -Name $($Config.serviceBusNamespaceName+$Config.suffix) -ResourceGroup $($Config.resourceGroupName+$Config.suffix)
         $Result.Location | Should Be $Config.location
     }
 

--- a/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
+++ b/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
@@ -3,11 +3,14 @@ Push-Location -Path $PSScriptRoot\..\Infrastructure\Resources\
 
 Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
 
+    $ResourceGroupName = "$($Config.resourceGroupName)$($Config.suffix)"
+    $ServiceBusName = "$($Config.serviceBusNamespaceName)$($Config.suffix)"
+
     It "Should create a Service Bus and return one output" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $($Config.resourceGroupName+$Config.suffix)
-            NamespaceName = $($Config.serviceBusNamespaceName+$Config.suffix)
+            ResourceGroupName = $ResourceGroupName
+            NamespaceName = $ServiceBusName
             QueueName = $Config.serviceBusQueueName
         }
         $Result = .\New-ServiceBus.ps1 @params
@@ -15,14 +18,14 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     }
 
     It "Should create a Service Bus in the correct location" {
-        $Result = Get-AzureRmServiceBusNamespace -Name $($Config.serviceBusNamespaceName+$Config.suffix) -ResourceGroup $($Config.resourceGroupName+$Config.suffix)
+        $Result = Get-AzureRmServiceBusNamespace -Name $ServiceBusName -ResourceGroup $ResourceGroupName
         $Result.Location | Should Be $Config.location
     }
 
     It "Should create specified Service Bus queues" {
         foreach($Queue in $Config.serviceBusQueueName){
             $Queue.Trim()
-            $ExistingQueue = Get-AzureRmServiceBusQueue -ResourceGroup $($Config.resourceGroupName+$Config.suffix) -NamespaceName $($Config.serviceBusNamespaceName+$Config.suffix) -QueueName $Queue
+            $ExistingQueue = Get-AzureRmServiceBusQueue -ResourceGroup $ResourceGroupName -NamespaceName $ServiceBusName -QueueName $Queue
             $ExistingQueue.Name | Should Be $Queue
         }
     }

--- a/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
+++ b/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
@@ -22,7 +22,7 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     It "Should create specified Service Bus queues" {
         foreach($Queue in $Config.serviceBusQueueName){
             $Queue.Trim()
-            $ExistingQueue = Get-AzureRmServiceBusQueue -ResourceGroup $Config.resourceGroupName -NamespaceName $Config.serviceBusNamespaceName -QueueName $Queue
+            $ExistingQueue = Get-AzureRmServiceBusQueue -ResourceGroup $($Config.resourceGroupName+$Config.suffix) -NamespaceName $($Config.serviceBusNamespaceName+$Config.suffix) -QueueName $Queue
             $ExistingQueue.Name | Should Be $Queue
         }
     }

--- a/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
+++ b/Tests/AT008.New-ServiceBus.Acceptance.Tests.ps1
@@ -6,8 +6,8 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     It "Should create a Service Bus and return one output" {
         $Params = @{
             Location = $Config.location
-            ResourceGroupName = $Config.resourceGroupName
-            NamespaceName = $Config.serviceBusNamespaceName
+            ResourceGroupName = $Config.resourceGroupName+$Config.suffix
+            NamespaceName = $Config.serviceBusNamespaceName+$Config.suffix
             QueueName = $Config.serviceBusQueueName
         }
         $Result = .\New-ServiceBus.ps1 @params
@@ -15,7 +15,7 @@ Describe "New-ServiceBus Tests" -Tag "Acceptance-ARM" {
     }
 
     It "Should create a Service Bus in the correct location" {
-        $Result = Get-AzureRmServiceBusNamespace -Name $Config.serviceBusNamespaceName -ResourceGroup $Config.resourceGroupName
+        $Result = Get-AzureRmServiceBusNamespace -Name $Config.serviceBusNamespaceName+$Config.suffix -ResourceGroup $Config.resourceGroupName+$Config.suffix
         $Result.Location | Should Be $Config.location
     }
 

--- a/Tests/Acceptance.Config.json
+++ b/Tests/Acceptance.Config.json
@@ -8,8 +8,10 @@
     "appServiceName": "devops-at-as",
     "appServicePlanName": "devops-at-asp",
     "serviceBusNamespaceName": "devops-at-sb",
-    "serviceBusQueueName": ["q1"],
+    "serviceBusQueueName": [
+        "q1"
+    ],
     "certificateName": "testcert.pfx",
     "certificatePassword": "password",
-    "suffix":  "812d5be5"
+    "suffix": "812d5be5"
 }

--- a/Tests/Acceptance.Config.json
+++ b/Tests/Acceptance.Config.json
@@ -9,7 +9,7 @@
     "appServicePlanName": "devops-at-asp",
     "serviceBusNamespaceName": "devops-at-sb",
     "serviceBusQueueName": ["q1"],
-    "certificatePath": "$(System.DefaultWorkingDirectory)\\testcert.pfx",
+    "certificatePath": ".\\testcert.pfx",
     "certificatePassword": "password",
     "suffix":  "812d5be5"
 }

--- a/Tests/Acceptance.Config.json
+++ b/Tests/Acceptance.Config.json
@@ -10,5 +10,6 @@
     "serviceBusNamespaceName": "devops-at-sb",
     "serviceBusQueueName": ["q1"],
     "certificatePath": "$(System.DefaultWorkingDirectory)\\testcert.pfx",
-    "certificatePassword": "password"
+    "certificatePassword": "password",
+    "suffix":  "812d5be5"
 }

--- a/Tests/Acceptance.Config.json
+++ b/Tests/Acceptance.Config.json
@@ -9,7 +9,7 @@
     "appServicePlanName": "devops-at-asp",
     "serviceBusNamespaceName": "devops-at-sb",
     "serviceBusQueueName": ["q1"],
-    "certificatePath": ".\\testcert.pfx",
+    "certificateName": "testcert.pfx",
     "certificatePassword": "password",
     "suffix":  "812d5be5"
 }

--- a/Tests/Cleanup-ARMResources.ps1
+++ b/Tests/Cleanup-ARMResources.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+Param()
+$Config = Get-Content $PSScriptRoot\..\Tests\Acceptance.Config.json -Raw | ConvertFrom-Json
+
+$ResourceGroupName = "$($Config.resourceGroupName)$($Config.suffix)"
+$CloudServiceName = "$($Config.cloudServiceName)$($Config.suffix)"
+$StorageAccountName = "$($Config.classicStorageAccountName)$($Config.suffix)"
+
+Write-Verbose -Message "Cleaning up Resource Group"
+$ResourceGroup = Get-AzureRMResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+if ($ResourceGroup) {
+    Remove-AzureRmResourceGroup -Name $ResourceGroupName -Force
+}
+else {
+    Write-Verbose -Message "Resource group does not exist"    
+}
+
+Write-Verbose -Message "Cleaning up Cloud service Resource Group"
+$CloudServiceResourceGroup = Get-AzureRmResourceGroup -Name $CloudServiceName -ErrorAction SilentlyContinue
+if ($CloudServiceResourceGroup) {
+    Remove-AzureRmResourceGroup -Name $CloudServiceName -Force
+}
+else {
+    Write-Verbose -Message "Cloud Service resource group does not exist"
+}
+
+Write-Verbose -Message "Cleaning up Storage account Resource Group"
+$StorageAccountResourceGroupResources = New-Object System.Collections.ArrayList
+ForEach ($resource in (Find-AzureRmResource -ResourceGroupNameEquals "Default-Storage-$($Config.location.replace(' ',''))")) {
+    $null = $StorageAccountResourceGroupResources.Add($resource)
+}
+
+if ($StorageAccountResourceGroupResources.Count -eq 1) {
+    if ($StorageAccountResourceGroupResources[0].ResourceName -like $StorageAccountName) {
+        Remove-AzureRmResourceGroup -Name "Default-Storage-$($Config.location.replace(' ',''))" -Force
+    }
+}
+elseif ($StorageAccountResourceGroupResources.Count -gt 1) {
+    Write-Verbose -Message "Default storage account resource group contains more than one resource, will not be deleted"
+}

--- a/Tests/Cleanup-ASMResources.ps1
+++ b/Tests/Cleanup-ASMResources.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+Param()
+$Config = Get-Content $PSScriptRoot\..\Tests\Acceptance.Config.json -Raw | ConvertFrom-Json
+
+$CloudServiceName = "$($Config.cloudServiceName)$($Config.suffix)"
+$StorageAccountName = "$($Config.classicStorageAccountName)$($Config.suffix)"
+
+Write-Verbose "Cleaning up cloud service"
+$CloudService = Get-AzureService -ServiceName $CloudServiceName -ErrorAction SilentlyContinue
+if ($CloudService) {
+    Write-Error "Cloud service resource group has not been removed and it cannot be removed using ASM authentication."
+    Remove-AzureService -ServiceName $CloudServiceName -Force
+}
+else {
+    Write-Verbose "Cloud service does not exist"
+}
+
+Write-Verbose "Cleaning up storage account"
+$StorageAccount = Get-AzureStorageAccount -StorageAccountName $StorageAccountName -ErrorAction SilentlyContinue
+if ($StorageAccount) {
+    Remove-AzureStorageAccount -StorageAccountName $StorageAccountName
+}
+else {
+    Write-Verbose "Storage account does not exist"
+}

--- a/Tests/Invoke-AcceptanceTests.ps1
+++ b/Tests/Invoke-AcceptanceTests.ps1
@@ -18,16 +18,16 @@ Invoke-AcceptanceTests.ps1 -Type ARM
 #>
 [CmdletBinding()]
 Param (
-    [Parameter(Mandatory=$true)]
-    [ValidateSet("ARM","ASM")]
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("ARM", "ASM")]
     [String]$Type
 )
 
 $TestParameters = @{
-    Tag = "Acceptance-$Type"
+    Tag          = "Acceptance-$Type"
     OutputFormat = 'NUnitXml'
-    OutputFile = "TEST-Acceptance.xml"
-    Script = "$PSScriptRoot"
+    OutputFile   = "TEST-Acceptance.xml"
+    Script       = "$PSScriptRoot"
 }
 
 Invoke-Pester @TestParameters


### PR DESCRIPTION
Use unique suffix appended to all resource names during test.

Successful test run on Build Agent

Setup script:
```
$Config = Get-Content $(System.DefaultWorkingDirectory)/devops-automation94/Tests/Acceptance.Config.json -Raw | ConvertFrom-Json
$Config.suffix = (New-Guid).Guid.Split("-")[0]
Set-Content -Path $(System.DefaultWorkingDirectory)/devops-automation94/Tests/Acceptance.Config.json -Value (ConvertTo-Json $Config)
```